### PR TITLE
Add the IP address parameter to authuser.

### DIFF
--- a/wimsapi/api.py
+++ b/wimsapi/api.py
@@ -341,7 +341,7 @@ class WimsAPI:
         return response['status'] == 'OK', response
     
     
-    def authuser(self, qclass, rclass, quser, hashlogin=None, verbose=False, code=None, **kwargs):
+    def authuser(self, qclass, rclass, quser, hashlogin=None, verbose=False, code=None, ip=None, **kwargs):
         """Get an authentification token for an user.
         
         User's password is not required.
@@ -356,6 +356,7 @@ class WimsAPI:
             qclass - (int) identifier of the class on the receiving server.
             rclass - (str) identifier of the class on the sending server.
             quser  - (str) user identifier on the receiving server.
+            ip     - (str) IP of the user trying to authenticate trough WimsAPI.
             hashlogin  - (str) hash function to use for an external authentification
             
         Return a session number under which the user can connect with no need of further
@@ -368,6 +369,7 @@ class WimsAPI:
                 'qclass': qclass,
                 'rclass': rclass,
                 'quser':  quser,
+                'data1': ip
             }
         }
         if hashlogin:

--- a/wimsapi/api.py
+++ b/wimsapi/api.py
@@ -341,7 +341,8 @@ class WimsAPI:
         return response['status'] == 'OK', response
     
     
-    def authuser(self, qclass, rclass, quser, hashlogin=None, verbose=False, code=None, ip=None, **kwargs):
+    def authuser(self, qclass, rclass, quser, hashlogin=None, verbose=False, code=None, ip=None,
+                 **kwargs):
         """Get an authentification token for an user.
         
         User's password is not required.


### PR DESCRIPTION
This fixes the issue in #6.

Unfortunately, I do not think this is enough to fix the more general problem of allowing WIMS-LTI to pass the IP address of the user to WIMS, since this information should come from the LMS, but it does not seem to be supported by the LTI protocol.

Nonetheless, this may be an useful addition to WimsAPI for other use cases.
